### PR TITLE
[Feat] : 고민 상담 태그 추가 

### DIFF
--- a/counsel_create.html
+++ b/counsel_create.html
@@ -76,7 +76,7 @@
                 <div class="group">
                     <input id="tags" class="create_input" type="text" required="required" maxlength="50" placeholder=""/><span
                         class="highlight"></span><span class="bar"></span>
-                    <label class="create_label">태그. 띄어쓰기로 구분해주세요</label>
+                    <label class="create_label">태그. 쉼표(,)로 구분 해주세요.</label>
                 </div>
                 <div class="group">
                     <textarea id="content" class="create_input" type="textarea" rows="10"

--- a/static/css/counsel.css
+++ b/static/css/counsel.css
@@ -450,5 +450,6 @@ span.active {
 
 /********* place 페이지네이션 시작 **********/
 .tag {
-    margin-left: 10px;
+    margin-left: 3px;
+    color: white;
 }

--- a/static/js/counsel_create.js
+++ b/static/js/counsel_create.js
@@ -5,14 +5,12 @@ async function CreateCounsel() {
     let content = document.querySelector('#content').value;
     let tags = document.querySelector('#tags').value;
     let checked = $('#anonymous-checkbox').is(':checked');
-
-    let taglist = [tags]
+    let tag = JSON.stringify ([tags])
 
     const formdata = new FormData();
     formdata.append("title", title);
     formdata.append("content", content);
-    formdata.append("tags", taglist);
-
+    formdata.append("tags", tag);
     if (checked) {
         formdata.append("is_anonymous", 'True');
 

--- a/static/js/counsel_detail.js
+++ b/static/js/counsel_detail.js
@@ -21,7 +21,7 @@ async function counselDetail(counsel_id) {
             let author_html = ``
             let counsel_author_id = response.counsel['user']['pk']
             let tags = response.counsel['tags']
-            let tag = String(tags).split(" ")
+            let tag = String(tags).split(",")
             if (is_anonymous) {
                 counsel_author = '익명'
                 author_html = `<span style = "color: rgb(158, 158, 158);">${counsel_author}</span>`
@@ -41,7 +41,7 @@ async function counselDetail(counsel_id) {
             $('#likes_count').append(likes_count)
             $('#counsel-created').append(counsel_created_at)
             for(let i = 0; i < tag.length; i++){
-                let tag_html = `<button class="tag_btn"><a class="tag_btn_a">${tag[i]}</a></button>`
+                let tag_html = `<a class="tag" href="counsel_list.html?tag=${tag[i]}"><${tag[i]}></a>`
                 $('#tags_container').append(tag_html)
             }
             
@@ -347,17 +347,15 @@ async function counselPreUpdate(counsel_id) {
         },
         method: "GET",
     })
-
     const response_json = await response.json();
-
     if (response_json['counsel'].is_anonymous) {
         anonymous = `
-        <div><input type="checkbox" id="anonymous-checkbox" checked>
+        <div style="width: 70%; margin: 0 auto;"><input type="checkbox" id="anonymous-checkbox" checked>
             <label for="counsel-edit-anonymous-checkbox">익명</label>
         </div>`
     } else {
         anonymous = `
-        <div><input type="checkbox" id="anonymous-checkbox">
+        <div style="width: 70%; margin: 0 auto;"><input type="checkbox" id="anonymous-checkbox">
             <label for="counsel-edit-anonymous-checkbox">익명</label>
         </div>`
     }
@@ -375,6 +373,11 @@ async function counselPreUpdate(counsel_id) {
                 <textarea id="counsel-edit-title" class="create_input" type="textarea" rows="1" required="required"
                     maxlength="50">${response_json['counsel'].title}</textarea><span class="highlight"></span><span class="bar"></span>
                 <label class="create_label">제목</label>
+            </div>
+            <div class="group">
+                <input id="tags" class="create_input" type="text" required="required" maxlength="50" value=${response_json['counsel'].tags}><span
+                    class="highlight"></span><span class="bar"></span>
+                <label class="create_label">태그. 쉼표(,)로 구분 해주세요.</label>
             </div>
             <div class="group">
                 <textarea id="counsel-edit-content" class="create_input" type="textarea" rows="10"
@@ -438,6 +441,7 @@ async function counselCommentCreate(id) {
 async function CounselEdit() {
     let title = document.querySelector('#counsel-edit-title').value
     let content = document.querySelector('#counsel-edit-content').value
+    let tags = document.querySelector('#tags').value;
     let checked = $('#counsel-edit-anonymous-checkbox').is(':checked');
     let is_anonymous = ''
     if (checked) {
@@ -456,7 +460,8 @@ async function CounselEdit() {
         body: JSON.stringify({
             title: title,
             content: content,
-            is_anonymous: is_anonymous
+            is_anonymous: is_anonymous,
+            tags: ([tags])
         })
     })
 

--- a/static/js/counsel_list_api.js
+++ b/static/js/counsel_list_api.js
@@ -4,10 +4,16 @@ const count_per_page = 15; // 페이지당 데이터 건수
 const show_page_cnt = 10; // 화면에 보일 페이지 번호 개수
 let page_data = 0;
 
-
+const urlParams = new URLSearchParams(window.location.search);
+const tag = urlParams.get('tag');
+if(tag){$(document).ready(function () {
+    tagshow()
+})
+}else{
 $(document).ready(function () {
     getCounsels()
 })
+}
 
 // 페이지네이션 시작
 $(function () {
@@ -123,7 +129,7 @@ async function getCounsels(pages = 1) {
                 let author_id = rows[i]['user']['pk']
                 let counsel_comment_count = rows[i]['comment_count']
                 let tags = rows[i]['tags']
-                let tag = String(tags).split(" ")
+                let tag = String(tags).split(",")
                 let tagsHtml = "";
                 let author_html = ``
                 if (is_anonymous) {
@@ -159,14 +165,13 @@ async function getCounsels(pages = 1) {
     })
 }
 
-
-
-function same_tags(tag) {
+function same_tags(tag_name) {
     $('#list-section').empty()
+    $('#myFooter').empty()
     $.ajax({
       url: `${BACKEND_BASE_URL}/counsel/tag/`,
       method: 'GET',
-      data: { tag: tag },
+      data: { tag: tag_name },
       success: function(response) {
         const rows = response;
         let foot = document.querySelector('#myFooter')
@@ -184,7 +189,7 @@ function same_tags(tag) {
             let author_id = rows[i]['user']['pk']
             let counsel_comment_count = rows[i]['comment_count']
             let tags = rows[i]['tags']
-            let tag = String(tags).split(" ")
+            let tag = String(tags).split(",")
             let tagsHtml = "";
             let author_html = ``
             if (is_anonymous) {
@@ -211,11 +216,76 @@ function same_tags(tag) {
             `
             $('#list-section').append(temp_html)
         }
-        // setPaging(pages);
     },
     error: function () {
         alert(response.status);
     }
 
 })
+}
+
+
+// const urlParams = new URLSearchParams(window.location.search);
+// const tag = urlParams.get('tag');
+// if (tag) {
+       function tagshow() {
+        $('#list-section').empty()
+        $('#myFooter').empty()
+  $.ajax({
+    url: `${BACKEND_BASE_URL}/counsel/tag/`,
+    method: 'GET',
+    data: { tag: tag },
+    success: function(response) {
+        
+        console.log(tag)
+        const rows = response;
+        let foot = document.querySelector('#myFooter')
+
+        foot.style.display = ''
+
+        for (let i = 0; i < rows.length; i++) {
+            let counsel_id = rows[i]['id']
+            let is_anonymous = rows[i]['is_anonymous']
+            let counsel_title = rows[i]['title']
+            let counsel_author = ''
+            
+            let counsel_created_at = rows[i]['created_at']
+            let likes_count = rows[i]['like'].length
+            let author_id = rows[i]['user']['pk']
+            let counsel_comment_count = rows[i]['comment_count']
+            let tags = rows[i]['tags']
+            let tag = String(tags).split(",")
+            let tagsHtml = "";
+            let author_html = ``
+            if (is_anonymous) {
+                counsel_author = '익명'
+                author_html = `<a style = "color: #9fbabf; cursor : text;">${counsel_author}</a>`
+            } else {
+                counsel_author = rows[i]['user']['nickname']
+                author_html = `<a onclick = "go_profile(${author_id})">${counsel_author}</a>`
+            }
+            for (let i = 0; i < tag.length; i++){
+                tagsHtml += `<a class="tag" onclick="same_tags('${tag[i]}')"><${tag[i]}></a>`;
+            }
+            let temp_html = `
+            <a onclick="go_counselDetail(${counsel_id})">
+                <div class="list-box">
+                    <div id="counsel-title">${counsel_title}<div id="counsel-comment-count">[${counsel_comment_count}]</div></div>
+                    <div id="counsel-author">${author_html}</div>
+                    <div id="counsel-created-at">${counsel_created_at}</div>
+                    <div id="counsel-likes">${likes_count}</div>
+                    <div id="tags_container" class="tags_container">${tagsHtml}</div>
+                </div>
+            </a>
+            <hr>
+            `
+            $('#list-section').append(temp_html)
+        }
+    },
+    error: function () {
+        alert(response.status);
+    }
+
+})
+
 }


### PR DESCRIPTION
-counsel_create.html 태그 작성시 쉼표로 구분해 달라는 문구
-counsel.css 태그 간격과 글자 색
-counsel_create.js 상담 글 작성시 태그 입력받아 데이터 보내기
-counsel_detail.js 상담 글 수정시 css 망가져서 수정, 태그 데이터 가져오기, 수정하기
-counsel_list.api.js 상담 글 보여주기 상세에서 태그 선택시, 글 목록에서 태그 선택시 같은 태그들 볼 수 있음
 하지만 페이지네이션 적용 못함. 원래 되던 페이지는 작동.